### PR TITLE
Custom error controller to gracefully handle unexpected errors

### DIFF
--- a/src/main/java/upeldev/com/github/upel3/controllers/ActivityController.java
+++ b/src/main/java/upeldev/com/github/upel3/controllers/ActivityController.java
@@ -121,7 +121,7 @@ public class ActivityController {
             if(currentUser.getCoursesEnrolledIn().contains(course)) return "activity_student";
 
             if(!currentUser.getRoles().contains(Role.ADMIN)){
-                model.addAttribute(errorMsg);
+                model.addAttribute("errorMsg", errorMsg);
                 return "error";
             }
 

--- a/src/main/java/upeldev/com/github/upel3/controllers/CustomErrorController.java
+++ b/src/main/java/upeldev/com/github/upel3/controllers/CustomErrorController.java
@@ -1,0 +1,39 @@
+package upeldev.com.github.upel3.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+import upeldev.com.github.upel3.model.User;
+import upeldev.com.github.upel3.services.CourseService;
+import upeldev.com.github.upel3.services.UserService;
+
+import java.security.Principal;
+
+@Controller
+public class CustomErrorController implements ErrorController {
+    private final UserService userService;
+    private final CourseService courseService;
+
+    @Autowired
+    public CustomErrorController(UserService userService, CourseService courseService){
+        this.userService = userService;
+        this.courseService = courseService;
+    }
+
+    @RequestMapping(value = "/error")
+    public String errorPage(Model model, Principal principal) {
+        User currentUser = userService.findByEmail(principal.getName());
+        model.addAttribute("user", currentUser);
+
+        String errorMsg = "Nieznany błąd";
+        model.addAttribute("errorMsg", errorMsg);
+        return "error";
+    }
+
+    @Override
+    public String getErrorPath() {
+        return null;
+    }
+}


### PR DESCRIPTION
Custom error controller to gracefully handle unexpected errors. Also fixed one controller that wasn't embedding the error message correctly.

This PR fixes issue #44.

Easiest way to check: visit non-existent site (such as http://localhost:8080/asdsdasdasd). Now it will gracefully show the error page unlike before.

Previously handled errors are not overrriden in this process. You still should be able to see appropriate message when visiting for example http://localhost:8080/activity?id=jbhjbhj